### PR TITLE
Fix topic variable name

### DIFF
--- a/python_script/awtrix_notify.py
+++ b/python_script/awtrix_notify.py
@@ -17,5 +17,5 @@ if work.get("moveIcon","") == "" :
 #work["force"]=True
 work["repeatIcon"]=True
 
-hass.services.call('mqtt', 'publish', { "topic": work["topix"]+"/notify", "payload":str(work) }, False)
+hass.services.call('mqtt', 'publish', { "topic": work["topic"]+"/notify", "payload":str(work) }, False)
 


### PR DESCRIPTION
Typo in variable name in MQTT publish service call, causing script not to work at all